### PR TITLE
Fixes a minor exception on program close

### DIFF
--- a/BAKKA_Editor/Views/MainView.axaml.cs
+++ b/BAKKA_Editor/Views/MainView.axaml.cs
@@ -713,15 +713,17 @@ public partial class MainView : UserControl
         if (tempFilePath == "")
             tempFilePath = PlatformUtils.GetTempFileName().Replace(".tmp", ".mer");
 
-        var tempFileStream = File.Open(tempFilePath, FileMode.Create);
-        if ((chart.Notes.Count > 0 || chart.Gimmicks.Count > 0) && !chart.IsSaved)
+        using (FileStream fileStream = File.Open(tempFilePath, FileMode.Create))
         {
-            chart.WriteFile(tempFileStream, false);
-            File.WriteAllLines(tempStatusPath, new[] {"true", DateTime.Now.ToString("yyyy-MM-dd HH:mm")});
-        }
-        else
-        {
-            DeleteAutosaves(tempFilePath);
+            if ((chart.Notes.Count > 0 || chart.Gimmicks.Count > 0) && !chart.IsSaved)
+            {
+                chart.WriteFile(fileStream, false);
+                File.WriteAllLines(tempStatusPath, new[] { "true", DateTime.Now.ToString("yyyy-MM-dd HH:mm") });
+            }
+            else
+            {
+                DeleteAutosaves(tempFilePath);
+            }
         }
     }
 


### PR DESCRIPTION
There's a chance to trigger an exception when closing the program. I was able to consistently reproduce it with the following steps. Also, this only has visible repercussions when debugging. When debugging, this causes the debugger to stop on the exception and potentially fail to delete the temporary file. There didn't seem to be any noticeable effect when testing a built executable.

1. Before opening the program, go to the temporary file location and sort by date modified so that you can see when temporary files are created. On Windows, this is accessed by going to "%tmp%" in the file explorer.
2. Start debugging.
3. Immediately set the Initial Chart Settings.
4. Wait for a .mer file to appear in the temporary folder. With default settings, this should take 1 minute.
5. Close the program the moment you notice the .mer file.
6. The debugger will pause where program exit tries to delete the temporary files.

I think this happens because there's a time period between when the file was opened by the filestream and when the program exit routine tries to delete the files where the files are left open by the filestream. Use `using` to properly handle the disposable filestream and close the file when done with it.